### PR TITLE
PS-915 - Upgrade GHA Workflow steps to run on pinned Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   pry
@@ -61,4 +62,4 @@ DEPENDENCIES
   safe_commit!
 
 BUNDLED WITH
-   2.3.19
+   2.3.23


### PR DESCRIPTION
This PR is to pin the workflow step versions to `22.04`, with the intent to identify any issues and fix those repos, and to move forward on a manual upgrade basis when the time and pipelines are ready.

## Context
GHA Workflows were set to run on `ubuntu-latest`, which worked fine until some of them failed when GitHub started upgrading the runners to resolve `latest` to `22.04` instead of the previous LTS, `20.04`.

See [PS-915](https://offerzen.atlassian.net/browse/PS-915?atlOrigin=eyJpIjoiMDEzM2E3YTJiOWY3NGYwYmFhMTY3YThiOWE0Nzc0NmIiLCJwIjoiaiJ9) for more info.f

[PS-915]: https://offerzen.atlassian.net/browse/PS-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-915]: https://offerzen.atlassian.net/browse/PS-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ