### PR TITLE
PS-1134 - Add Relevant Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a dependabot configuration file tailored to this repository in order to enable automatic dependency maintenance and updates.

## Context
Dependabot was built to make our dependency management easier, but it only helps if it knows which dependencies your projects have, and where to locate them.
In order to take advantage of this, remove the workload from humans and ensure we get security and other updates regularly, we need to create these configuration files for each repo.

See [**PS-1134**](https://offerzen.atlassian.net/browse/PS-1134) for more info.