### PR TITLE
[PS-1940] Update GHA Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.0.5'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
GHA workflow file updates:

- Update GHA `actions/checkout` to the latest version

Please see [**PS-1940**](https://offerzen.atlassian.net/browse/PS-1940) for more context.